### PR TITLE
Checking for name collisions wasn't case sensitive.

### DIFF
--- a/src/models/parsed-wsdl.ts
+++ b/src/models/parsed-wsdl.ts
@@ -77,11 +77,11 @@ export class ParsedWsdl {
     /** To make every definition's name unique. If definition with same name exists, suffix it with incremented number */
     findNonCollisionDefinitionName(defName: string): string {
         const definitionName = sanitizeFilename(defName);
-        if (!this.definitions.find((def) => def.name === definitionName)) {
+        if (!this.definitions.find((def) => def.name.toLowerCase() === definitionName.toLowerCase())) {
             return definitionName;
         }
         for (let i = 1; i < MAX_STACK; i++) {
-            if (!this.definitions.find((def) => def.name === `${definitionName}${i}`)) {
+            if (!this.definitions.find((def) => def.name.toLowerCase() === `${definitionName.toLowerCase()}${i}`)) {
                 return `${definitionName}${i}`;
             }
         }


### PR DESCRIPTION
The example issue was datasetValue vs dataSetValue.
We would end up with a name collision in the exports due to a difference
in casing only. Modifing the check to look for name.lowerCase() resolves
this and the definitions propogate throughout the rest of the files
appropriately.